### PR TITLE
리팩토링: FormDataEncoderTest 에러 임시 해결

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/domain/ForForm.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/ForForm.java
@@ -1,0 +1,4 @@
+package com.fastcampus.projectboard.domain;
+
+public class ForForm {
+}

--- a/src/test/java/com/fastcampus/projectboard/util/FormDataEncoderTest.java
+++ b/src/test/java/com/fastcampus/projectboard/util/FormDataEncoderTest.java
@@ -1,5 +1,6 @@
 package com.fastcampus.projectboard.util;
 
+import com.fastcampus.projectboard.domain.ForForm;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,7 +15,7 @@ import static org.assertj.core.api.Assertions.*;
 
 @DisplayName("테스트 도구 - Form 데이터 인코더")
 @Import({FormDataEncoder.class, ObjectMapper.class})
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = Void.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = ForForm.class)
 class FormDataEncoderTest {
 
     private final FormDataEncoder formDataEncoder;
@@ -72,4 +73,7 @@ class FormDataEncoderTest {
         ONE, TWO, THREE
     }
 
+    public class ForTestForm{
+
+    }
 }


### PR DESCRIPTION
FormDataEncoderTest를 진행하는데 에러가 생겼던 문제를 임시로 main에 ForForm 이라는 빈 클래스를 만들어 Void.class 대신 넣어줬다.

FormDataEncoderTest 테스트 안의 Inner class로 만들어줘도 에러가 발생하는것을 보니 아마 FormDataEncoder자체를 인식하는데 문제가 있는거 같기도하고...우선은 아직 잘 모르겠다.

+) JDK 버전도 17버전이 맞음 settings와 Project structure를 통해 확인함!